### PR TITLE
Bump generic-chart version

### DIFF
--- a/zally/requirements.yaml
+++ b/zally/requirements.yaml
@@ -1,5 +1,5 @@
 dependencies:
   - name: generic-chart
-    version: 0.2.0
+    version: 0.3.0
     repository: https://registry.baloise.dev/chartrepo/library
     alias: generic


### PR DESCRIPTION
I only uploaded 0.3.0 in the new installation of harbor. 
https://registry.baloise.dev/harbor/projects/1/helm-charts/generic-chart/versions